### PR TITLE
Add torch.compile benchmarking option

### DIFF
--- a/eagle/evaluation/speed.py
+++ b/eagle/evaluation/speed.py
@@ -1,52 +1,36 @@
+import argparse
 import json
-from transformers import AutoTokenizer
-import numpy as np
-
-tokenizer=AutoTokenizer.from_pretrained("/home/lyh/weights/hf/llama2chat/13B/")
-jsonl_file = "llama-2-chat-70b-fp16-ea-in-temperature-0.0.jsonl"
-jsonl_file_base = "llama-2-chat-70b-fp16-base-in-temperature-0.0.jsonl"
-data = []
-with open(jsonl_file, 'r', encoding='utf-8') as file:
-    for line in file:
-        json_obj = json.loads(line)
-        data.append(json_obj)
 
 
-
-speeds=[]
-for datapoint in data:
-    qid=datapoint["question_id"]
-    answer=datapoint["choices"][0]['turns']
-    tokens=sum(datapoint["choices"][0]['new_tokens'])
-    times = sum(datapoint["choices"][0]['wall_time'])
-    speeds.append(tokens/times)
-
-
-data = []
-with open(jsonl_file_base, 'r', encoding='utf-8') as file:
-    for line in file:
-        json_obj = json.loads(line)
-        data.append(json_obj)
+def compute_speed(path: str) -> float:
+    """Compute tokens per second from a benchmark jsonl file."""
+    total_tokens = 0
+    total_time = 0.0
+    with open(path, "r", encoding="utf-8") as file:
+        for line in file:
+            data = json.loads(line)
+            tokens = sum(data["choices"][0]["new_tokens"])
+            times = sum(data["choices"][0]["wall_time"])
+            total_tokens += tokens
+            total_time += times
+    return total_tokens / total_time if total_time > 0 else 0.0
 
 
-total_time=0
-total_token=0
-speeds0=[]
-for datapoint in data:
-    qid=datapoint["question_id"]
-    answer=datapoint["choices"][0]['turns']
-    tokens = 0
-    for i in answer:
-        tokens += (len(tokenizer(i).input_ids) - 1)
-    times = sum(datapoint["choices"][0]['wall_time'])
-    speeds0.append(tokens / times)
-    total_time+=times
-    total_token+=tokens
+def main():
+    parser = argparse.ArgumentParser(description="Compute generation speed from answer files")
+    parser.add_argument("--file", required=True, help="Answer file produced by evaluation script")
+    parser.add_argument("--baseline-file", help="Optional baseline file for comparison")
+    args = parser.parse_args()
+
+    speed = compute_speed(args.file)
+    print(f"speed: {speed}")
+
+    if args.baseline_file:
+        baseline_speed = compute_speed(args.baseline_file)
+        print(f"baseline speed: {baseline_speed}")
+        if baseline_speed > 0:
+            print(f"ratio: {speed / baseline_speed}")
 
 
-
-# print('speed',np.array(speeds).mean())
-# print('speed0',np.array(speeds0).mean())
-print("ratio",np.array(speeds).mean()/np.array(speeds0).mean())
-
-
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `--torch-compile` flag to LLaMA3 chat evaluation
- report average tokens/sec after evaluation
- create `speed.py` utility to compute tokens/sec and compare with baseline

## Testing
- `python -m py_compile eagle/evaluation/gen_ea_answer_llama3chat.py eagle/evaluation/speed.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890557baf30832e8991fc46676fc836