### PR TITLE
Enable Triton kernels across tree decoding

### DIFF
--- a/eagle/model/triton_kernels/README.md
+++ b/eagle/model/triton_kernels/README.md
@@ -150,3 +150,5 @@ The integration module (`integration.py`) provides a high-level interface for us
 - Support for mixed precision (FP16/BF16) computation
 - Dynamic kernel selection based on input size and hardware capabilities
 - Integration with other acceleration techniques, such as FlashAttention and quantization
+- Design a fused speculative decoding mega kernel combining draft generation,
+  verification, KV-cache updates and input sequence updates

--- a/eagle/model/triton_kernels/mega_kernel.py
+++ b/eagle/model/triton_kernels/mega_kernel.py
@@ -1,0 +1,22 @@
+"""Placeholder for fused speculative decoding mega kernel.
+
+This module sketches the interface for a future Triton kernel that fuses
+several steps of the speculative decoding pipeline:
+
+- Draft-token generation
+- Candidate verification against the base model
+- KV-cache updates
+- Input sequence updates
+
+The actual kernel implementation is left as future work and will require
+coordinated tiling across sequence, head and vocabulary dimensions.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+def triton_mega_kernel(*args, **kwargs):
+    """Placeholder function for future fused kernel."""
+    raise NotImplementedError("Mega kernel is not yet implemented")


### PR DESCRIPTION
## Summary
- switch KV cache helpers to launch Triton kernels on CUDA while keeping PyTorch fallback
- add naive Triton implementations for top-k search, tree mask construction, and posterior evaluation
- outline a future fused "mega kernel" in documentation and code skeleton

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_689115f6bc8c832e8fea101c05643357